### PR TITLE
add RN methodQueue method

### DIFF
--- a/ios/TCWrapper.m
+++ b/ios/TCWrapper.m
@@ -8,6 +8,11 @@
 
 @implementation TCWrapper
 
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(initTagCommander: (int) siteID andContainerID: (int) containerID)


### PR DESCRIPTION
When running with the latest version of the TCSDK/TCCore, I ran into this issue:

`Main Thread Checker: UI API called on a background thread: -[WKWebView .cxx_construct]`

The RN docs provide some documentation on this: https://facebook.github.io/react-native/docs/native-modules-ios#threading

This PR moves the call to the main thread.

I've tested this with RN 0.61.1, TCSDK 4.4.1 and TCCore 4.5.1 (Universal, Bitcode enabled).